### PR TITLE
rhel7 cert, centos7, travis, makefile, & arbitrary uid support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: required
+dist: trusty
+
+services:
+ - docker
+
+addons:
+  apt:
+    packages:
+    - nodejs
+    - jq
+
+install:
+  - npm install -g dockerfile_lint
+
+before_script:
+  - mkdir $HOME/bin
+  - export PATH=$PATH:$HOME/bin
+  - tmp=`mktemp`
+  - echo 'DOCKER_OPTS="$DOCKER_OPTS --insecure-registry 172.30.0.0/16"' > ${tmp}
+  - sudo mv ${tmp} /etc/default/docker
+  - sudo mount --make-shared /
+  - sudo service docker restart
+
+script:
+  - make lint
+  - make
+  - make test
+  - wget `curl -s https://api.github.com/repos/openshift/origin/releases/latest | jq -r ".assets[] | select(.name | test(\"linux-64bit\")) | .browser_download_url" | grep -i client-tools`
+  - tar xvfz `ls openshift-origin-client-tools-*.tar.gz` --strip-components=1 -C $HOME/bin
+  - oc cluster up
+  - export OC_USER=`oc whoami` OC_PASS=`oc whoami -t`
+  - oc login -u system:admin
+  - oc rollout status -w dc/docker-registry -n default || oc rollout retry dc/docker-registry -n default && oc rollout status -w dc/docker-registry -n default
+  - export REGISTRY_IP=`oc get svc/docker-registry -o json -n default | jq -r '.spec.clusterIP'`
+  - make openshift-test REGISTRY=${REGISTRY_IP} OC_USER=${OC_USER} OC_PASS=${OC_PASS}
+  - oc version

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -28,8 +28,7 @@ RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms && \
       gcc make openssl-devel pcre-devel zlib-devel tar curl socat && \
     curl -sfSL "$HAPROXY_SRC_URL/$HAPROXY_BRANCH/src/haproxy-$HAPROXY_MINOR.tar.gz" -o haproxy.tar.gz && \
     echo "$HAPROXY_MD5  haproxy.tar.gz" | md5sum -c - && \
-    groupadd "$HAPROXY_GID" && \
-    useradd -g "$HAPROXY_GID" "$HAPROXY_UID" && \
+    useradd -l -u ${HAPROXY_UID} -r -G 0 -s /sbin/nologin -c "haproxy user" haproxy && \
     mkdir -p /tmp/haproxy && \
     tar -xzf haproxy.tar.gz -C /tmp/haproxy --strip-components=1 && \
     rm -f haproxy.tar.gz && \
@@ -38,9 +37,11 @@ RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms && \
                             all install-bin install-man && \
     ln -s /usr/local/sbin/haproxy /usr/sbin/haproxy && \
     mkdir -p /var/lib/haproxy && \
+    chown -R ${HAPROXY_UID}:0 /var/lib/haproxy && \
+    chmod -R g+rw /var/lib/haproxy && \
     cp /tmp/haproxy/doc/haproxy.1 /help.1 && \
     rm -rf /tmp/haproxy && \
-    yum remove -y gcc make && \
+    yum -y autoremove gcc make && \
     yum clean all
 
 ADD ./cfg_files/cli /usr/bin/cli

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM docker.io/centos:7
+FROM registry.access.redhat.com/rhel7
 MAINTAINER Dinko Korunic <dkorunic@haproxy.com>
 
 LABEL name="haproxytech/haproxy" \
@@ -21,10 +21,15 @@ ENV HAPROXY_SRC_URL http://www.haproxy.org/download
 
 ENV HAPROXY_UID 10001
 
-RUN yum -y install --setopt=tsflags=nodocs gcc make openssl-devel pcre-devel zlib-devel tar curl socat && \
+RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms && \
+    yum -y update-minimal --disablerepo "*" --enablerepo rhel-7-server-rpms --setopt=tsflags=nodocs \
+      --security --sec-severity=Important --sec-severity=Critical && \
+    yum -y install --disablerepo "*" --enablerepo ${REPOLIST} --setopt=tsflags=nodocs \
+      gcc make openssl-devel pcre-devel zlib-devel tar curl socat && \
     curl -sfSL "$HAPROXY_SRC_URL/$HAPROXY_BRANCH/src/haproxy-$HAPROXY_MINOR.tar.gz" -o haproxy.tar.gz && \
     echo "$HAPROXY_MD5  haproxy.tar.gz" | md5sum -c - && \
-    useradd -l -u ${HAPROXY_UID} -r -G 0 -s /sbin/nologin -c "haproxy user" haproxy && \
+    groupadd "$HAPROXY_GID" && \
+    useradd -g "$HAPROXY_GID" "$HAPROXY_UID" && \
     mkdir -p /tmp/haproxy && \
     tar -xzf haproxy.tar.gz -C /tmp/haproxy --strip-components=1 && \
     rm -f haproxy.tar.gz && \
@@ -33,11 +38,9 @@ RUN yum -y install --setopt=tsflags=nodocs gcc make openssl-devel pcre-devel zli
                             all install-bin install-man && \
     ln -s /usr/local/sbin/haproxy /usr/sbin/haproxy && \
     mkdir -p /var/lib/haproxy && \
-    chown -R ${HAPROXY_UID}:0 /var/lib/haproxy && \
-    chmod -R g+rw /var/lib/haproxy && \
     cp /tmp/haproxy/doc/haproxy.1 /help.1 && \
     rm -rf /tmp/haproxy && \
-    yum -y autoremove gcc make && \
+    yum remove -y gcc make && \
     yum clean all
 
 ADD ./cfg_files/cli /usr/bin/cli

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+CONTEXT = haproxytech
+VERSION = 1.7.5
+IMAGE_NAME = openshift-haproxy
+TARGET = centos7
+REGISTRY = docker-registry.default.svc.cluster.local
+OC_USER = developer
+OC_PASS = developer
+
+# Allow user to pass in OS build options
+ifeq ($(TARGET),rhel7)
+	DFILE := Dockerfile.${TARGET}
+else
+	DFILE := Dockerfile
+endif
+
+all: build
+build:
+	docker build --pull -t ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} -t ${CONTEXT}/${IMAGE_NAME} -f ${DFILE} .
+	@if docker images ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}; then touch build; fi
+
+lint:
+	dockerfile_lint -f Dockerfile
+	dockerfile_lint -f Dockerfile.rhel7
+
+test:
+	$(eval CONTAINERID=$(shell docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	@sleep 2
+	@docker exec ${CONTAINERID} curl localhost:8080
+	@docker exec ${CONTAINERID} ps aux
+	@docker rm -f ${CONTAINERID}
+
+openshift-test:
+	$(eval PROJ_RANDOM=$(shell shuf -i 100000-999999 -n 1))
+	oc login -u ${OC_USER} -p ${OC_PASS}
+	oc new-project test-${PROJ_RANDOM}
+	docker login -u ${OC_USER} -p ${OC_PASS} ${REGISTRY}:5000
+	docker tag ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} ${REGISTRY}:5000/test-${PROJ_RANDOM}/${IMAGE_NAME}
+	docker push ${REGISTRY}:5000/test-${PROJ_RANDOM}/${IMAGE_NAME}
+	oc new-app -i ${IMAGE_NAME}
+	oc rollout status -w dc/${IMAGE_NAME}
+	oc status
+	sleep 5
+	oc describe pod `oc get pod --template '{{(index .items 0).metadata.name }}'`
+	curl `oc get svc/${IMAGE_NAME} -o json | jq -r '.spec.clusterIP'`:8080
+
+run:
+	docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) -p 8080:8080 ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}
+
+clean:
+	rm -f build

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ openshift-test:
 	sleep 5
 	oc describe pod `oc get pod --template '{{(index .items 0).metadata.name }}'`
 	curl `oc get svc/${IMAGE_NAME} -o json | jq -r '.spec.clusterIP'`:8080
+	oc exec `oc get pod --template '{{(index .items 0).metadata.name }}'` ps aux
 
 run:
 	docker run -tdi -u $(shell shuf -i 1000010000-1000020000 -n 1) -p 8080:8080 ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}

--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ system with Software Collections entitlements available.
 
 To build the Dockerfile, run:
 ```
-# cd openshift-haproxy
-# docker build -t=haproxy .
+$ cd openshift-haproxy
+# build on centos7
+$ make
+
+# OR build on rhel7
+# make TARGET=rhel7
+
+$ make run
+$ curl localhost:8080
 
 General container help
 ----------------------

--- a/cfg_files/haproxy.cfg
+++ b/cfg_files/haproxy.cfg
@@ -25,12 +25,14 @@ global
     #
     log         127.0.0.1 local2
 
-    chroot      /var/lib/haproxy
-    pidfile     /var/run/haproxy.pid
-    maxconn     4000
-    user        haproxy
-    group       haproxy
+    # unecessary since already in a container and using an arbitrary uid
+    # chroot      /var/lib/haproxy
+    # user        haproxy
+    # group       haproxy
     # daemon
+
+    pidfile     /var/lib/haproxy/haproxy.pid
+    maxconn     4000
 
     # turn on stats unix socket
     stats socket /var/lib/haproxy/stats
@@ -56,13 +58,14 @@ defaults
     timeout http-keep-alive 10s
     timeout check           10s
     maxconn                 3000
+    default-server          init-addr last,libc,none
 
 #---------------------------------------------------------------------
 # main frontend which proxys to the backends
 #---------------------------------------------------------------------
 frontend  main
-    bind *:80
-    # bind *:443 ssl # To be completed ....
+    bind *:8080
+    # bind *:8443 ssl # To be completed ....
 
     acl url_static       path_beg       -i /static /images /javascript /stylesheets
     acl url_static       path_end       -i .jpg .gif .png .css .js
@@ -82,8 +85,8 @@ backend static
 # round robin balancing between the various backends
 #---------------------------------------------------------------------
 backend app
-    balance     roundrobin
-    server  app1 127.0.0.1:5001 check
+    balance roundrobin
+    server  app1 router.default.svc.cluster.local:80 check
     server  app2 127.0.0.1:5002 check
     server  app3 127.0.0.1:5003 check
     server  app4 127.0.0.1:5004 check


### PR DESCRIPTION
This build has been sucessfully tested w/o the need for anyuid scc in openshift.  Test w/ a new project, default settings:
```shell
$ oc new-app docker.io/tchughesiv/openshift-haproxy
$ oc expose svc/openshift-haproxy
```
The rhel7 build is built to pass RH certification.